### PR TITLE
[Cleanup] update ignore and add Railway notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,8 +63,7 @@ logs/
 bot_config.json
 bot_config_dev.json
 logic.txt
-railyway.json
-admin_tools.py
+railway.json
 .env
 
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ Each system supports customizable notification timing:
 
 ---
 
+## 🚈 Hosting on Railway
+
+1. Fork this repo or connect it directly in Railway.
+2. Create a new project and add the `KINGSHOT_BOT_TOKEN` variable in the dashboard.
+3. Set the start command to `python bot.py` (or keep the provided `Procfile`).
+4. Deploy and monitor the logs to confirm the bot starts.
+
+---
+
 ## 🆘 Support
 
 **Need help? Join our support server!**

--- a/admin_tools.py
+++ b/admin_tools.py
@@ -1,0 +1,11 @@
+"""Compatibility layer exposing admin functions from command_center."""
+
+from command_center import handle_command, live_feed, start_command_center
+
+
+def start_admin_tools(bot):
+    """Start admin tools via the command center."""
+    start_command_center(bot)
+
+
+__all__ = ["start_admin_tools", "handle_command", "live_feed"]


### PR DESCRIPTION
## Summary
- fix file name in `.gitignore`
- document basic Railway deployment steps

## Testing Done
- `flake8 admin_tools.py`
- `black admin_tools.py --check`
- `DISCORD_ENABLED=0 python bot.py` *(fails once cogs load since no login)*

------
https://chatgpt.com/codex/tasks/task_e_686175e38d3c8324a9e997e3b158e6ee